### PR TITLE
Add 'decimal' and 'double' to supported field types

### DIFF
--- a/ddl/check.lua
+++ b/ddl/check.lua
@@ -52,6 +52,8 @@ local function check_field(i, field, space)
             array     = true,
             map       = true,
             any       = true,
+            decimal   = true,
+            double    = true,
         }
 
         if known_field_types[field.type] == nil then


### PR DESCRIPTION
Recent versions of Tarantool added support for 'decimal' and 'double'
field types to both Lua and SQL. Add them to DDL as well to support
creating spaces with those field types.