### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.1.0] - 2020-03-18
+## [1.1.0] - 2020-04-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.0] - 2020-03-18
+
 ### Added
 
 - Support `decimal` and `double` types for tarantool 2.3
 
 ### Fixed
 
-- Removed unnecessary logs
-- Fixed error messages
+- Remove unnecessary logs
+- Fix error messages
 
 ## [1.0.0] - 2019-11-28
 


### PR DESCRIPTION
## [1.1.0] - 2020-04-09

### Added

- Support `decimal` and `double` types for tarantool 2.3

### Fixed

- Remove unnecessary logs
- Fix error messages
