### PR TITLE
Allow custom fields in space format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow custom fields in space format
+
 ## [1.2.0] - 2020-07-20
 
 ### Added

--- a/ddl/check.lua
+++ b/ddl/check.lua
@@ -73,14 +73,13 @@ local function check_field(i, field, space)
     end
 
 
-    do -- check redundant keys
-        local k = utils.redundant_key(field,
-            {'name', 'type', 'is_nullable'}
-        )
-        if k ~= nil then
+    -- non-string keys are forbidden
+    for k, _ in pairs(field) do
+        if type(k) ~= 'string' then
             return nil, string.format(
-                "spaces[%q].format[%q]: redundant key %q",
-                space.name, field.name, k
+                "spaces[%q].format[%q]: bad key %s" ..
+                " (string expected, got %s)",
+                space.name, field.name, k, type(k)
             )
         end
     end

--- a/test/check_schema_test.lua
+++ b/test/check_schema_test.lua
@@ -38,6 +38,8 @@ local test_space = {
         {name = 'double_null', type = 'double', is_nullable = true},
         {name = 'uuid_nonnull', type = 'uuid', is_nullable = false},
         {name = 'uuid_null', type = 'uuid', is_nullable = true},
+
+        {name = 'annotated', type = 'any', is_nullable = true, comment = 'x'},
     },
 }
 

--- a/test/set_schema_test.lua
+++ b/test/set_schema_test.lua
@@ -890,6 +890,31 @@ function g.test_missing_format()
     )
 end
 
+function g.test_annotated_format()
+    local schema = {spaces = table.deepcopy(test_space)}
+    schema.spaces.test.indexes = {{
+        type = 'TREE',
+        unique = true,
+        name = 'primary',
+        parts = {{path = 'unsigned_nonnull', type = 'unsigned', is_nullable = false}}
+    }}
+
+    local k = 1ULL
+    schema.spaces.test.format[2][k] = 'forbidden-cdata'
+    local res, err = ddl.set_schema(schema)
+    t.assert_equals(res, nil)
+    t.assert_equals(err,
+        'spaces["test"].format["unsigned_nullable"]:' ..
+        ' bad key 1ULL (string expected, got cdata)'
+    )
+    schema.spaces.test.format[2][k] = nil
+
+    schema.spaces.test.format[1].scale = 'bananas'
+    local res, err = ddl.set_schema(schema)
+    t.assert_equals({res, err}, {true, nil})
+    t.assert_equals(ddl.get_schema(), schema)
+end
+
 function g.test_missing_indexes()
     local schema = {spaces = table.deepcopy(test_space)}
     schema.spaces.test.indexes = nil


### PR DESCRIPTION
Tarantool allows space format to have custom fields. And users say it
may be valuable. This patch allows to add custom `space.format` fields,
for example

```lua
spaces = {
  test = {
    format = {{
      name = 'size',
      type = 'number',
      scale = 'bananas',
    }},
  }
}
```

The only restriction is that a custom field must be a string.

Close #36