### PR TITLE
Make schema top-level keys validation stricter

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: rosik/setup-tarantool@v1
+      - uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: '2.5'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@master
-      - uses: rosik/setup-tarantool@v1
+      - uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Allow custom fields in space format
+- Forbid redundant keys in schema top-level and make `spaces` table
+  mandatory. So the only valid schema format now is `{spaces = {...}}`.
 
 ## [1.2.0] - 2020-07-20
 


### PR DESCRIPTION
- Forbid redundant keys in schema top-level
- Make `spaces` table mandatory

So the only valid schema format is `{spaces = {...}}`.


Related to https://github.com/tarantool/cartridge/issues/1117