### PR TITLE
update tarantool versions in CI targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-20.04]
-        tarantool: ['1.10', '2.4', '2.5', '2.6', '2.7']
+        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8']
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This patch bumps Tarantool versions to be tested in CI.