### PR TITLE
Create a cartridge role for ddl.get_schema. ddl-manager migration from cartridge to ddl repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       -
         run: tarantoolctl rocks install luatest
         if: steps.cache-rocks.outputs.cache-hit != 'true'
+      -
+        run: tarantoolctl rocks install cartridge
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 
       - run: luacheck .
@@ -38,4 +40,5 @@ jobs:
       - run: luatest -v
 
       # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge
       - run: tarantoolctl rocks remove ddl

--- a/cartridge/roles/schema-api.lua
+++ b/cartridge/roles/schema-api.lua
@@ -1,0 +1,137 @@
+local log = require('log')
+local ddl = require('ddl')
+local yaml = require('yaml')
+local checks = require('checks')
+local errors = require('errors')
+
+local failover = require('cartridge.failover')
+
+local SetSchemaError = errors.new_class('SetSchemaError')
+local CheckSchemaError = errors.new_class('CheckSchemaError')
+local DecodeYamlError = errors.new_class('DecodeYamlError')
+
+local _section_name = 'schema.yml'
+local _example_schema = [[## Example:
+#
+# spaces:
+#   customer:
+#     engine: memtx
+#     is_local: false
+#     temporary: false
+#     sharding_key: [customer_id]
+#     format:
+#       - {name: customer_id, type: unsigned, is_nullable: false}
+#       - {name: bucket_id, type: unsigned, is_nullable: false}
+#       - {name: fullname, type: string, is_nullable: false}
+#     indexes:
+#     - name: customer_id
+#       unique: true
+#       type: TREE
+#       parts:
+#         - {path: customer_id, type: unsigned, is_nullable: false}
+#
+#     - name: bucket_id
+#       unique: false
+#       type: TREE
+#       parts:
+#         - {path: bucket_id, type: unsigned, is_nullable: false}
+#
+#     - name: fullname
+#       unique: true
+#       type: TREE
+#       parts:
+#         - {path: fullname, type: string, is_nullable: false}
+]]
+
+local function _from_yaml(schema_yml)
+    if type(schema_yml) ~= 'string' then
+        return nil, CheckSchemaError:new(
+                'Section %q must be a string, got %s',
+                _section_name, type(schema_yml)
+        )
+    end
+
+    return DecodeYamlError:pcall(yaml.decode, schema_yml)
+end
+
+-- set schema from yaml
+local function apply_config(conf, opts)
+    checks('table', { is_master = 'boolean' })
+
+    if not opts.is_master then
+        return true
+    end
+
+    if conf[_section_name] == nil then
+        return true
+    end
+
+    local schema, err = _from_yaml(conf[_section_name])
+    if schema == nil then
+        if err then
+            return nil, err
+        else
+            return true
+        end
+    end
+
+    local ok, err = ddl.set_schema(schema)
+    if not ok then
+        return nil, SetSchemaError:new(err)
+    end
+
+    return true
+end
+
+-- check schema from yaml
+local function validate_config(conf_new, _)
+    checks('table', 'table')
+
+    if conf_new[_section_name] == nil then
+        return true
+    end
+
+    local schema, err = _from_yaml(conf_new[_section_name])
+    if schema == nil then
+        if err then
+            return nil, err
+        else
+            return true
+        end
+    end
+
+    if type(box.cfg) == 'function' then
+        log.info(
+                "Schema validation skipped because" ..
+                        " the instance isn't bootstrapped yet"
+        )
+        return true
+    elseif not failover.is_leader() then
+        log.info(
+                "Schema validation skipped because" ..
+                        " the instance isn't a leader"
+        )
+        return true
+    end
+
+    local ok, err = ddl.check_schema(schema)
+    if not ok then
+        return nil, CheckSchemaError:new(err)
+    end
+
+    return true
+end
+
+local function init()
+    rawset(_G, 'ddl', ddl)
+end
+
+return {
+    role_name = 'schema-api',
+    _section_name = _section_name,
+    _example_schema = _example_schema,
+    apply_config = apply_config,
+    validate_config = validate_config,
+    init = init,
+    permanent = true
+}

--- a/ddl-scm-1.rockspec
+++ b/ddl-scm-1.rockspec
@@ -8,6 +8,7 @@ source  = {
 dependencies = {
     'lua >= 5.1';
     'tarantool';
+    'checks';
 }
 
 description = {

--- a/test/db.lua
+++ b/test/db.lua
@@ -10,7 +10,9 @@ end)
 
 local function init()
     box.cfg{
-        work_dir = tempdir,
+        memtx_dir = tempdir,
+        vinyl_dir = tempdir,
+        wal_dir = tempdir,
     }
 end
 

--- a/test/entrypoint/schema-api_role_init.lua
+++ b/test/entrypoint/schema-api_role_init.lua
@@ -1,0 +1,14 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+
+local cartridge = require('cartridge')
+local ok, err = cartridge.cfg({
+    workdir = 'tmp/db',
+    roles = {
+        'cartridge.roles.schema-api'
+    },
+    cluster_cookie = 'schema-api-cluster-cookie',
+})
+
+assert(ok, tostring(err))

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,0 +1,43 @@
+require('strict').on()
+
+local log = require('log')
+local digest = require('digest')
+local fio = require('fio')
+
+local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
+if not ok then
+    log.error('Please, install cartridge rock to run tests')
+    os.exit(1)
+end
+
+local helpers = table.copy(cartridge_helpers)
+
+helpers.project_root = fio.dirname(debug.sourcedir())
+
+local __fio_tempdir = fio.tempdir
+fio.tempdir = function(base)
+    base = base or os.getenv('TMPDIR')
+    if base == nil or base == '/tmp' then
+        return __fio_tempdir()
+    else
+        local random = digest.urandom(9)
+        local suffix = digest.base64_encode(random, {urlsafe = true})
+        local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)
+        fio.mktree(path)
+        return path
+    end
+end
+
+function helpers.entrypoint(name)
+    local path = fio.pathjoin(
+            helpers.project_root,
+            'test', 'entrypoint',
+            string.format('%s.lua', name)
+    )
+    if not fio.path.exists(path) then
+        error(path .. ': no such entrypoint', 2)
+    end
+    return path
+end
+
+return helpers

--- a/test/integration/schema-api_role_test.lua
+++ b/test/integration/schema-api_role_test.lua
@@ -1,0 +1,172 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group('schema-api')
+
+local helpers = require('test.helper')
+
+math.randomseed(os.time())
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('schema-api_role_init'),
+        replicasets = {
+            {
+                uuid = helpers.uuid('a'),
+                alias = 'schema-api',
+                roles = { 'schema-api' },
+                servers = {
+                    { instance_uuid = helpers.uuid('a', 1), alias = 'schema-api' },
+                },
+            }
+        }
+    })
+    g.cluster:start()
+    g._section_name = 'schema.yml'
+    g._example_schema = [[
+     spaces:
+       customer:
+         engine: memtx
+         is_local: false
+         temporary: false
+         sharding_key: [customer_id]
+         format:
+           - {name: customer_id, type: unsigned, is_nullable: false}
+           - {name: bucket_id, type: unsigned, is_nullable: false}
+           - {name: fullname, type: string, is_nullable: false}
+         indexes:
+         - name: customer_id
+           unique: true
+           type: TREE
+           parts:
+             - {path: customer_id, type: unsigned, is_nullable: false}
+
+         - name: bucket_id
+           unique: false
+           type: TREE
+           parts:
+             - {path: bucket_id, type: unsigned, is_nullable: false}
+
+         - name: fullname
+           unique: true
+           type: TREE
+           parts:
+             - {path: fullname, type: string, is_nullable: false}
+    ]]
+    g.tbl_with_test_schema = {}
+    g.tbl_with_test_schema[g._section_name] = g._example_schema
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+g.test_ddl_get_schema = function()
+
+    local tbl = g.cluster.main_server.net_box:call("ddl.get_schema")
+    t.assert_equals(tbl['spaces'], {})
+
+    g.cluster.main_server.net_box:eval([[
+        box.schema.space.create("test1")
+    ]])
+    tbl = g.cluster.main_server.net_box:call("ddl.get_schema")
+    t.assert_equals(tbl['spaces'], {
+        test1 = {
+            engine = "memtx",
+            format = {},
+            indexes = {},
+            is_local = false,
+            temporary = false,
+        },
+    })
+
+    g.cluster.main_server.net_box:eval([[
+        box.schema.space.create("test2")
+    ]])
+    tbl = g.cluster.main_server.net_box:call("ddl.get_schema")
+    t.assert_equals(tbl['spaces'], {
+        test1 = {
+            engine = "memtx",
+            format = {},
+            indexes = {},
+            is_local = false,
+            temporary = false,
+        },
+        test2 = {
+            engine = "memtx",
+            format = {},
+            indexes = {},
+            is_local = false,
+            temporary = false,
+        },
+    })
+
+end
+
+g.test_validate_config = function()
+    local _, err = g.cluster.main_server.net_box:eval([[
+        schema_api = require('cartridge.roles.schema-api')
+        return schema_api.validate_config(...)
+    ]], { g.tbl_with_test_schema, {} })
+    t.assert_equals(err, nil)
+end
+
+g.test_apply_config = function()
+
+    local _, err = g.cluster.main_server.net_box:eval([[
+        schema_api = require('cartridge.roles.schema-api')
+        return schema_api.apply_config(...)
+    ]], { g.tbl_with_test_schema, { is_master = true } })
+
+    t.assert_equals(err, nil)
+
+    local tbl = g.cluster.main_server.net_box:call("ddl.get_schema")
+    t.assert_equals(tbl['spaces'], {
+        customer = {
+            engine = "memtx",
+            format = {
+                { is_nullable = false, name = "customer_id", type = "unsigned" },
+                { is_nullable = false, name = "bucket_id", type = "unsigned" },
+                { is_nullable = false, name = "fullname", type = "string" },
+            },
+            indexes = {
+                {
+                    name = "customer_id",
+                    parts = { { is_nullable = false, path = "customer_id", type = "unsigned" } },
+                    type = "TREE",
+                    unique = true,
+                },
+                {
+                    name = "bucket_id",
+                    parts = { { is_nullable = false, path = "bucket_id", type = "unsigned" } },
+                    type = "TREE",
+                    unique = false,
+                },
+                {
+                    name = "fullname",
+                    parts = { { is_nullable = false, path = "fullname", type = "string" } },
+                    type = "TREE",
+                    unique = true,
+                },
+            },
+            is_local = false,
+            sharding_key = { "customer_id" },
+            temporary = false,
+        },
+        test1 = {
+            engine = "memtx",
+            format = {},
+            indexes = {},
+            is_local = false,
+            temporary = false,
+        },
+        test2 = {
+            engine = "memtx",
+            format = {},
+            indexes = {},
+            is_local = false,
+            temporary = false,
+        },
+    })
+end


### PR DESCRIPTION
# RFC: ddl-manager migration from cartridge to ddl repo. DDL  role for cartridge from box. 

* **Status**: In progress
* **Start date**: 03-02-2021
* **Issues**:  tarantool/ddl#50, tarantool/cartridge-java#54

## Summary
ddl-manager will locate with its parent(ddl). DDL get_schema role for cartridge from box.

## Background and motivation
Due to this migration, it is possible not to store two roles in parallel.
It is possible to simplify the code for the cartridge, using the logical ddl manager together with ddl itself.
DDL role does not need to be written manually by users, it comes out of the box along with the ddl package.
Possibility of accepting the scheme in yaml format and translating it into ddl format for users from box.

## Design Proposal
What to do with this code, just for the ddl manager it is not needed.
We are going to leave this code in the cartridge:
https://github.com/tarantool/ddl/blob/f010977d78b5bef362fe6a66ef798a36d9690445/cartridge/ddl-manager.lua#L101-L113

The idea is to make a call to ddl-manager functions from ddl api:
https://github.com/tarantool/ddl/blob/f010977d78b5bef362fe6a66ef798a36d9690445/ddl.lua#L149-L158

It is also worth renaming the function name to a logical format for translating yaml:
https://github.com/tarantool/ddl/blob/f010977d78b5bef362fe6a66ef798a36d9690445/cartridge/ddl-manager.lua#L57
https://github.com/tarantool/ddl/blob/f010977d78b5bef362fe6a66ef798a36d9690445/cartridge/ddl-manager.lua#L85

Instead of the entire config with the name of the section, etc., these functions will receive only the scheme.