### PR TITLE
Add the ddl-manager from cartridge as a new role

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         id: cache-rocks
         with:
           path: .rocks/
-          key: cache-rocks-${{ matrix.runs-on }}-01
+          key: cache-rocks-${{ matrix.runs-on }}-04
       -
         run: tarantoolctl rocks install luacheck
         if: steps.cache-rocks.outputs.cache-hit != 'true'
@@ -33,9 +33,16 @@ jobs:
         if: steps.cache-rocks.outputs.cache-hit != 'true'
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 
+      - run: tarantoolctl rocks list
+      - run: tarantoolctl rocks install cartridge
+        env:
+          CMAKE_DUMMY_WEBUI: true
+      - run: tarantoolctl rocks remove ddl --force
+
       - run: luacheck .
       - run: tarantoolctl rocks make
       - run: luatest -v
 
       # Cleanup cached paths
+      - run: tarantoolctl rocks remove cartridge
       - run: tarantoolctl rocks remove ddl

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 .rocks
 /build.luarocks
+/tmp
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Use transactional ddl when applying schema
+- Use transactional ddl when applying schema.
+- Transfer "ddl-manager" role from the cartridge repo.
 
 ## [1.3.0] - 2020-12-25
 
 ### Added
 
-- Allow custom fields in space format
+- Allow custom fields in space format.
 - Forbid redundant keys in schema top-level and make `spaces` table
   mandatory. So the only valid schema format now is `{spaces = {...}}`.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ install(
   DESTINATION ${TARANTOOL_INSTALL_LUADIR}/
 )
 
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/cartridge/roles/ddl-manager.lua
+  DESTINATION ${TARANTOOL_INSTALL_LUADIR}/cartridge/roles/
+)
+
 file(GLOB_RECURSE LUA_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/ddl/*.lua"
 )

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DDL module for Tarantool 1.10+
 
 ## API
 
- - ### Set spaces format
+### Set spaces format
     `ddl.set_schema(schema)`
     - If no spaces existed before, create them.
     - If a space exists, check the space's format and indexes.
@@ -28,13 +28,13 @@ DDL module for Tarantool 1.10+
 
     Return values: `true` if no error, otherwise return `nil, err`
 
-  - ### Check compatibility
+### Check compatibility
     `ddl.check_schema(schema)`
     - Check that a `set_schema()` call will raise no error.
 
     Return values: `true` if no error, otherwise return `nil, err`
 
-  - ### Get spaces format
+### Get spaces format
     `ddl.get_schema()`
     - Scan spaces and return the database schema.
 

--- a/cartridge/roles/ddl-manager.lua
+++ b/cartridge/roles/ddl-manager.lua
@@ -1,0 +1,288 @@
+local log = require('log')
+local ddl = require('ddl')
+local yaml = require('yaml').new()
+local errors = require('errors')
+
+local cartridge = require('cartridge')
+local failover = require('cartridge.failover')
+
+local CheckSchemaError = errors.new_class('CheckSchemaError')
+
+yaml.cfg({
+    encode_use_tostring = true,
+    encode_load_metatables = false,
+    decode_save_metatables = false,
+})
+
+local _section_name = 'schema.yml'
+local _example_schema = [[## Example:
+#
+# spaces:
+#   customer:
+#     engine: memtx
+#     is_local: false
+#     temporary: false
+#     sharding_key: [customer_id]
+#     format:
+#       - {name: customer_id, type: unsigned, is_nullable: false}
+#       - {name: bucket_id, type: unsigned, is_nullable: false}
+#       - {name: fullname, type: string, is_nullable: false}
+#     indexes:
+#     - name: customer_id
+#       unique: true
+#       type: TREE
+#       parts:
+#         - {path: customer_id, type: unsigned, is_nullable: false}
+#
+#     - name: bucket_id
+#       unique: false
+#       type: TREE
+#       parts:
+#         - {path: bucket_id, type: unsigned, is_nullable: false}
+#
+#     - name: fullname
+#       unique: true
+#       type: TREE
+#       parts:
+#         - {path: fullname, type: string, is_nullable: false}
+]]
+
+local function apply_config(conf, opts)
+    if not opts.is_master then
+        return true
+    end
+
+    local schema_yml = conf[_section_name]
+    if schema_yml == nil then
+        return true
+    end
+
+    assert(type(schema_yml) == 'string')
+
+    local schema = yaml.decode(schema_yml)
+    if schema == nil then
+        return true
+    end
+
+    assert(ddl.set_schema(schema))
+    return true
+end
+
+local function validate_config(conf_new, _)
+    local schema_yml = conf_new[_section_name]
+    if schema_yml == nil then
+        return true
+    end
+
+    local schema = yaml.decode(schema_yml)
+    if schema == nil then
+        return true
+    end
+
+    if type(box.cfg) == 'function' then
+        log.info(
+            "Schema validation skipped because" ..
+            " the instance isn't bootstrapped yet"
+        )
+        return true
+    elseif not failover.is_leader() then
+        log.info(
+            "Schema validation skipped because" ..
+            " the instance isn't a leader"
+        )
+        return true
+    end
+
+    local ok, err = ddl.check_schema(schema)
+    if not ok then
+        return nil, CheckSchemaError:new(err)
+    end
+
+    return true
+end
+
+local function init()
+    rawset(_G, 'ddl', ddl)
+end
+
+local function stop()
+    rawset(_G, 'ddl', nil)
+end
+
+--- Get clusterwide schema as a YAML string.
+--
+-- In case there's no schema set, return a commented out example.
+--
+-- @function get_clusterwide_schema_yaml
+-- @treturn string yaml-encoded schema
+local function get_clusterwide_schema_yaml()
+    local schema_yml = cartridge.config_get_readonly(_section_name)
+
+    if schema_yml == nil or schema_yml == '' then
+        return _example_schema
+    else
+        return schema_yml
+    end
+end
+
+--- Get clusterwide schema as a Lua table.
+--
+-- In case there's no schema set, return empty schema `{spaces = {}}`.
+--
+-- @function get_clusterwide_schema_lua
+-- @treturn table schema
+local function get_clusterwide_schema_lua()
+    local schema_yml = cartridge.config_get_readonly(_section_name)
+    local schema_lua = schema_yml and yaml.decode(schema_yml)
+    if schema_lua == nil then
+        return {spaces = {}}
+    else
+        return schema_lua
+    end
+end
+
+--- Apply schema (as a YAML string) on a whole cluster.
+--
+-- @function set_clusterwide_schema_yaml
+-- @tparam string schema_yml
+-- @treturn[1] boolean `true`
+-- @treturn[2] nil
+-- @treturn[2] table Error object
+local function set_clusterwide_schema_yaml(schema_yml)
+    local patch
+    if schema_yml == nil then
+        patch = {[_section_name] = box.NULL}
+    elseif type(schema_yml) ~= 'string' then
+        local err = string.format(
+            'Bad argument #1 to set_clusterwide_schema_yaml' ..
+            ' (?string expected, got %s)', type(schema_yml)
+        )
+        error(err, 2)
+    else
+        patch = {[_section_name] = schema_yml}
+    end
+
+    return cartridge.config_patch_clusterwide(patch)
+end
+
+--- Apply schema (as a Lua table) on a whole cluster.
+--
+-- @function set_clusterwide_schema_lua
+-- @tparam string schema_lua
+-- @treturn[1] boolean `true`
+-- @treturn[2] nil
+-- @treturn[2] table Error object
+local function set_clusterwide_schema_lua(schema_lua)
+    local patch
+    if schema_lua == nil then
+        patch = {[_section_name] = box.NULL}
+    elseif type(schema_lua) ~= 'table' then
+        local err = string.format(
+            'Bad argument #1 to set_clusterwide_schema_lua' ..
+            ' (?table expected, got %s)', type(schema_lua)
+        )
+        error(err, 2)
+    else
+        patch = {[_section_name] = yaml.encode(schema_lua)}
+    end
+
+    return cartridge.config_patch_clusterwide(patch)
+end
+
+--- Validate schema passed as a YAML string.
+--
+-- @function check_schema_yaml
+-- @tparam string schema_yml
+-- @treturn[1] boolean `true`
+-- @treturn[2] nil
+-- @treturn[2] table Error object
+local function check_schema_yaml(schema_yml)
+    if schema_yml == nil then
+        return true
+    elseif type(schema_yml) ~= 'string' then
+        return nil, CheckSchemaError:new(
+            'Bad argument #1 to check_schema_yaml' ..
+            ' (?string expected, got %s)', type(schema_yml)
+        )
+    end
+
+    local ok, schema_lua = pcall(yaml.decode, schema_yml)
+    if not ok then
+        return nil, CheckSchemaError:new(
+            'Invalid YAML: %s', schema_lua
+        )
+    end
+
+    if schema_lua == nil then
+        return true
+    end
+
+    if not failover.is_leader() then
+        return cartridge.rpc_call(
+            'ddl-manager', 'check_schema_yaml', {schema_yml},
+            {leader_only = true}
+        )
+    end
+
+    local ok, err = ddl.check_schema(schema_lua)
+    if not ok then
+        return nil, CheckSchemaError:new(err)
+    end
+
+    return true
+end
+
+--- Validate schema passed as a Lua table.
+--
+-- @function check_schema_lua
+-- @tparam string schema_lua
+-- @treturn[1] boolean `true`
+-- @treturn[2] nil
+-- @treturn[2] table Error object
+local function check_schema_lua(schema_lua)
+    if schema_lua == nil then
+        return true
+    elseif type(schema_lua) ~= 'table' then
+        return nil, CheckSchemaError:new(
+            'Bad argument #1 to check_schema_lua' ..
+            ' (?table expected, got %s)', type(schema_lua)
+        )
+    end
+
+    -- Always perform encode + decode because
+    -- that's how `set_schema_lua` works
+    local ok, schema_yml = pcall(yaml.encode, schema_lua)
+    if not ok then
+        return nil, CheckSchemaError:new(
+            'Encoding YAML failed: %s', schema_yml
+        )
+    end
+
+    return cartridge.rpc_call(
+        'ddl-manager', 'check_schema_yaml', {schema_yml},
+        {prefer_local = true, leader_only = true}
+    )
+end
+
+return {
+    role_name = 'ddl-manager',
+    permanent = true,
+    _section_name = _section_name,
+    _example_schema = _example_schema,
+
+    init = init,
+    stop = stop,
+    validate_config = validate_config,
+    apply_config = apply_config,
+
+    get_clusterwide_schema_yaml = get_clusterwide_schema_yaml,
+    get_clusterwide_schema_lua = get_clusterwide_schema_lua,
+
+    set_clusterwide_schema_yaml = set_clusterwide_schema_yaml,
+    set_clusterwide_schema_lua = set_clusterwide_schema_lua,
+
+    check_schema_yaml = check_schema_yaml,
+    check_schema_lua = check_schema_lua,
+
+    CheckSchemaError = CheckSchemaError,
+}

--- a/test/db.lua
+++ b/test/db.lua
@@ -10,7 +10,9 @@ end)
 
 local function init()
     box.cfg{
-        work_dir = tempdir,
+        memtx_dir = tempdir,
+        vinyl_dir = tempdir,
+        wal_dir = tempdir,
     }
 end
 

--- a/test/entrypoint/srv_basic.lua
+++ b/test/entrypoint/srv_basic.lua
@@ -1,0 +1,13 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+
+local cartridge = require('cartridge')
+local ok, err = cartridge.cfg({
+    workdir = 'tmp/db',
+    roles = {
+        'cartridge.roles.ddl-manager',
+    }
+})
+
+assert(ok, tostring(err))

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,16 +1,8 @@
 require('strict').on()
 
-local log = require('log')
-local digest = require('digest')
 local fio = require('fio')
-
-local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
-if not ok then
-    log.error('Please, install cartridge rock to run tests')
-    os.exit(1)
-end
-
-local helpers = table.copy(cartridge_helpers)
+local digest = require('digest')
+local helpers = table.copy(require('luatest').helpers)
 
 helpers.project_root = fio.dirname(debug.sourcedir())
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,0 +1,43 @@
+require('strict').on()
+
+local log = require('log')
+local digest = require('digest')
+local fio = require('fio')
+
+local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
+if not ok then
+    log.error('Please, install cartridge rock to run tests')
+    os.exit(1)
+end
+
+local helpers = table.copy(cartridge_helpers)
+
+helpers.project_root = fio.dirname(debug.sourcedir())
+
+local __fio_tempdir = fio.tempdir
+fio.tempdir = function(base)
+    base = base or os.getenv('TMPDIR')
+    if base == nil or base == '/tmp' then
+        return __fio_tempdir()
+    else
+        local random = digest.urandom(9)
+        local suffix = digest.base64_encode(random, {urlsafe = true})
+        local path = fio.pathjoin(base, 'tmp.cartridge.' .. suffix)
+        fio.mktree(path)
+        return path
+    end
+end
+
+function helpers.entrypoint(name)
+    local path = fio.pathjoin(
+            helpers.project_root,
+            'test', 'entrypoint',
+            string.format('%s.lua', name)
+    )
+    if not fio.path.exists(path) then
+        error(path .. ': no such entrypoint', 2)
+    end
+    return path
+end
+
+return helpers

--- a/test/role_test.lua
+++ b/test/role_test.lua
@@ -1,15 +1,17 @@
-local fio = require('fio')
 local t = require('luatest')
 local g = t.group()
 
+local fio = require('fio')
 local yaml = require('yaml')
 local helpers = require('test.helper')
-local ddl_manager = require('cartridge.roles.ddl-manager')
-
-math.randomseed(os.time())
 
 g.before_all(function()
-    g.cluster = helpers.Cluster:new({
+    t.skip_if(
+        not pcall(require, 'cartridge'),
+        'cartridge not installed'
+    )
+
+    g.cluster = require('cartridge.test-helpers').Cluster:new({
         datadir = fio.tempdir(),
         server_command = helpers.entrypoint('srv_basic'),
         replicasets = {{
@@ -38,6 +40,7 @@ g.after_all(function()
 end)
 
 local function get_section()
+    local ddl_manager = require('cartridge.roles.ddl-manager')
     return g.s1.net_box:call(
         'package.loaded.cartridge.config_get_readonly',
         {ddl_manager._section_name}

--- a/test/role_test.lua
+++ b/test/role_test.lua
@@ -1,0 +1,363 @@
+local fio = require('fio')
+local t = require('luatest')
+local g = t.group()
+
+local yaml = require('yaml')
+local helpers = require('test.helper')
+local ddl_manager = require('cartridge.roles.ddl-manager')
+
+math.randomseed(os.time())
+
+g.before_all(function()
+    g.cluster = helpers.Cluster:new({
+        datadir = fio.tempdir(),
+        server_command = helpers.entrypoint('srv_basic'),
+        replicasets = {{
+            alias = 'main',
+            roles = {},
+            servers = 2,
+        }},
+    })
+
+    g.space = {
+        engine = "memtx",
+        format = {},
+        indexes = {},
+        is_local = false,
+        temporary = false,
+    }
+
+    g.cluster:start()
+    g.s1 = g.cluster:server('main-1')
+    g.s2 = g.cluster:server('main-2')
+end)
+
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
+
+local function get_section()
+    return g.s1.net_box:call(
+        'package.loaded.cartridge.config_get_readonly',
+        {ddl_manager._section_name}
+    )
+end
+
+local function srv_call(srv, fn_name, ...)
+    return srv.net_box:eval([[
+        local fn_name, args = ...
+        local cartridge = require('cartridge')
+        local ddl_manager = cartridge.service_get('ddl-manager')
+        return ddl_manager[fn_name](unpack(args))
+    ]], {fn_name, {...}})
+end
+
+local function call(fn_name, ...)
+    return srv_call(g.s1, fn_name, ...)
+end
+
+function g.test_yaml()
+    --------------------------------------------------------------------
+    local schema = ''
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), '')
+
+    --------------------------------------------------------------------
+    local schema = nil
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), nil)
+
+    --------------------------------------------------------------------
+    local schema = ' '
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_equals(call('get_clusterwide_schema_yaml'), ' ')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), ' ')
+
+    --------------------------------------------------------------------
+    local schema = box.NULL
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), nil)
+
+    --------------------------------------------------------------------
+    local schema = 'null'
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_equals(call('get_clusterwide_schema_yaml'), 'null')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), 'null')
+
+    --------------------------------------------------------------------
+    local schema = 'spaces: {}'
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_equals({ok, err}, {true, nil})
+    t.assert_equals(call('get_clusterwide_schema_yaml'), 'spaces: {}')
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(get_section(), 'spaces: {}')
+
+    --------------------------------------------------------------------
+    local schema = 'not-a-table'
+    local expected_error = 'Invalid schema (table expected, got string)'
+
+    local ok, err = srv_call(g.s1, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    --------------------------------------------------------------------
+    local schema = '{}'
+    local expected_error = 'spaces: must be a table, got nil'
+
+    local ok, err = srv_call(g.s1, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    --------------------------------------------------------------------
+    local schema = ']['
+
+    local ok, err = srv_call(g.s1, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = 'Invalid YAML: unexpected END event',
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = 'Invalid YAML: unexpected END event',
+    })
+
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'LoadConfigError',
+        err = 'Error parsing section "schema.yml": unexpected END event',
+    })
+
+    --------------------------------------------------------------------
+    local schema = {}
+    local expected_error = 'Bad argument #1 to check_schema_yaml' ..
+        ' (?string expected, got table)'
+
+    local ok, err = srv_call(g.s1, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_yaml', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    t.assert_error_msg_equals(
+        'Bad argument #1 to set_clusterwide_schema_yaml' ..
+        ' (?string expected, got table)',
+        call, 'set_clusterwide_schema_yaml', schema
+    )
+
+    --------------------------------------------------------------------
+    local schema = yaml.encode({spaces = {s_yaml = g.space}})
+
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_covers(
+        g.s1.net_box:call('ddl.get_schema').spaces,
+        {s_yaml = g.space}
+    )
+
+    t.assert_equals(
+        call('get_clusterwide_schema_lua'),
+        {spaces = {s_yaml = g.space}}
+    )
+end
+
+function g.test_lua()
+    --------------------------------------------------------------------
+    local schema = {spaces = {}}
+    local ok, err = call('check_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    local yml = '---\nspaces: []\n...\n'
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_equals(call('get_clusterwide_schema_yaml'), yml)
+    t.assert_equals(get_section(), yml)
+
+    --------------------------------------------------------------------
+    local schema = box.NULL
+    local ok, err = call('check_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
+    t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
+    t.assert_equals(get_section(), nil)
+
+    --------------------------------------------------------------------
+    local schema = {}
+    local expected_error = 'spaces: must be a table, got nil'
+
+    local ok, err = srv_call(g.s1, 'check_schema_lua', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_lua', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    local ok, err = call('set_clusterwide_schema_lua', {})
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = '"localhost:13301": ' .. expected_error,
+    })
+
+    --------------------------------------------------------------------
+    local schema = '{}'
+    local expected_error = 'Bad argument #1 to check_schema_lua' ..
+        ' (?table expected, got string)'
+
+    local ok, err = srv_call(g.s1, 'check_schema_lua', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    local ok, err = srv_call(g.s2, 'check_schema_lua', schema)
+    t.assert_equals(ok, nil)
+    t.assert_covers(err, {
+        class_name = 'CheckSchemaError',
+        err = expected_error,
+    })
+
+    t.assert_error_msg_equals(
+        'Bad argument #1 to set_clusterwide_schema_lua' ..
+        ' (?table expected, got string)',
+        call, 'set_clusterwide_schema_lua', '{}'
+    )
+
+    --------------------------------------------------------------------
+    local schema = {spaces = {s_lua = g.space}}
+
+    local ok, err = call('check_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    local ok, err = call('set_clusterwide_schema_lua', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    t.assert_covers(
+        g.s1.net_box:call('ddl.get_schema').spaces,
+        {s_lua = g.space}
+    )
+    t.assert_equals(
+        yaml.decode(call('get_clusterwide_schema_yaml')),
+        {spaces = {s_lua = g.space}}
+    )
+end
+
+function g.test_example_schema()
+    local fun = require('fun')
+    local schema = fun.map(
+        function(l) return l:gsub('^# ', '') end,
+        call('get_clusterwide_schema_yaml'):split('\n')
+    ):totable()
+    schema = table.concat(schema, '\n')
+
+    local ok, err = call('check_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+    local ok, err = call('set_clusterwide_schema_yaml', schema)
+    t.assert_equals({ok, err}, {true, nil})
+
+    local space_name = next(yaml.decode(schema).spaces)
+
+    for _, srv in pairs(g.cluster.servers) do
+        helpers.retrying({}, function()
+            srv.net_box:ping()
+            t.assert(srv.net_box.space[space_name],
+                string.format('Missing space %q on %s', space_name, srv.alias)
+            )
+        end)
+    end
+end


### PR DESCRIPTION
This is an extended version of #51.

* The role is renamed back to `ddl-manager`.
* Implement `stop()` callback for the sake of reloadability.
* Remove from CI the other `ddl` version installed by cartridge.
* Add the role to the cmake installer (it was missing in the original patch).
* Provide the API to be used in cartridge and test it a lot:

```lua
get_clusterwide_schema_yaml() -- return "spaces: {}"
get_clusterwide_schema_lua() -- return {spaces = {}}

set_clusterwide_schema_yaml("spaces: {}") -- return true
set_clusterwide_schema_lua({spaces = {}}) -- return true

check_schema_yaml("spaces: {}") -- return true
check_schema_lua({spaces = {}}) -- return true
```

Close #50 