### PR TITLE
Store schema example in the clusterwide config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- If one applies an empty schema using the 'ddl-manager' role API,
+  put in the clusterwide configuration an example instead.
+
 ## [1.4.0] - 2021-04-22
 
 ### Added

--- a/test/db.lua
+++ b/test/db.lua
@@ -22,6 +22,7 @@ local function drop_all()
     end
 end
 
+-- Check if tarantool version >= required
 local function v(req_major, req_minor)
     req_minor = req_minor or 0
     assert(type(req_major) == 'number')

--- a/test/role_test.lua
+++ b/test/role_test.lua
@@ -70,7 +70,7 @@ function g.test_yaml()
 
     t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
     t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
-    t.assert_equals(get_section(), '')
+    t.assert_equals(call('get_clusterwide_schema_yaml'), get_section())
 
     --------------------------------------------------------------------
     local schema = nil
@@ -81,7 +81,7 @@ function g.test_yaml()
 
     t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
     t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
-    t.assert_equals(get_section(), nil)
+    t.assert_equals(call('get_clusterwide_schema_yaml'), get_section())
 
     --------------------------------------------------------------------
     local schema = ' '
@@ -103,7 +103,7 @@ function g.test_yaml()
 
     t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
     t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
-    t.assert_equals(get_section(), nil)
+    t.assert_equals(call('get_clusterwide_schema_yaml'), get_section())
 
     --------------------------------------------------------------------
     local schema = 'null'
@@ -269,7 +269,7 @@ function g.test_lua()
 
     t.assert_equals(call('get_clusterwide_schema_lua'), {spaces = {}})
     t.assert_str_matches(call('get_clusterwide_schema_yaml'), '## Example:\n.+')
-    t.assert_equals(get_section(), nil)
+    t.assert_equals(call('get_clusterwide_schema_yaml'), get_section())
 
     --------------------------------------------------------------------
     local schema = {}

--- a/test/set_schema_test.lua
+++ b/test/set_schema_test.lua
@@ -638,6 +638,17 @@ function g.test_path()
         }
     })
 
+    local error_expected
+    if db.v(2, 8) then
+        -- See: https://github.com/tarantool/tarantool/issues/4707
+        error_expected = 'spaces["test"].indexes["path_idx"]:' ..
+            " Field 1 (unsigned_nonnull) has type 'unsigned' in one index," ..
+            " but type 'map' in another"
+    else
+        error_expected = 'spaces["test"].indexes["path_idx"]:' ..
+            " Field 1 has type 'unsigned' in one index," ..
+            " but type 'map' in another"
+    end
     _test_index({
         {
             name = 'path_idx',
@@ -645,9 +656,7 @@ function g.test_path()
             unique = true,
             parts = {{path = 'unsigned_nonnull.DATA["name"]', type = 'unsigned', is_nullable = false}}
         }},
-        [[spaces["test"].indexes["path_idx"]: Field 1 has type 'unsigned' in one index, but type 'map' in another]]
-        -- [[spaces["test"].indexes["path_idx"].parts[1].path: path (unsigned_nonnull.DATA["name"])]] ..
-        -- [[ is json_path. It references to field[unsigned_nonnull] with type unsigned, but expected map]]
+        error_expected
     )
 
     _test_index({pk, {
@@ -718,6 +727,19 @@ function g.test_multikey_path()
         }
     }})
 
+
+
+    local error_expected
+    if db.v(2, 8) then
+        -- See: https://github.com/tarantool/tarantool/issues/4707
+        error_expected = 'spaces["test"].indexes["path_idx"]:' ..
+            " Field 15 (map_nonnull) has type 'map' in one index," ..
+            " but type 'array' in another"
+    else
+        error_expected = 'spaces["test"].indexes["path_idx"]:' ..
+            " Field 15 has type 'map' in one index," ..
+            " but type 'array' in another"
+    end
     _test_index({pk, {
             name = 'path_idx',
             type = 'TREE',
@@ -729,7 +751,7 @@ function g.test_multikey_path()
                 }
             }
         }},
-        [[spaces["test"].indexes["path_idx"]: Field 15 has type 'map' in one index, but type 'array' in another]]
+        error_expected
     )
 
     _test_index({


### PR DESCRIPTION
If one applies an empty schema using the 'ddl-manager' role API, put in the clusterwide configuration an example instead.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation

Part of https://github.com/tarantool/cartridge/issues/1085
See also https://github.com/tarantool/cartridge/pull/1194
