### PR TITLE
Make a space with sharding keys as a part of API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Name and format of a space `_ddl_sharding_key` is a part of public API.
+
 ### Changed
 
 - If one applies an empty schema using the 'ddl-manager' role API,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ DDL module for Tarantool 1.10+
 
     Return values: `true` if no error, otherwise return `nil, err`
 
+Additionally when a section `sharding_key` is not empty in YAML schema call of
+function `ddl.set_schema(schema)` creates a space `_ddl_sharding_key` with two
+fields: `space_name` with type `string` and `sharding_key` with type `array`.
+
 ### Check compatibility
     `ddl.check_schema(schema)`
     - Check that a `set_schema()` call will raise no error.


### PR DESCRIPTION
This commit exposes space name `_ddl_sharding_key` and it's format as a
part of public API. Everyone allowed to get and set sharding keys there
using DDL module or it's own code. Rigth now space `_ddl_sharding_key`
is used in `migrations` module to register sharding key [1].

1. https://github.com/tarantool/migrations/blob/master/migrator/utils.lua#L20-L39