### PR TITLE
Update info in README about _ddl_sharding_key space creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ in [documementation](https://www.tarantool.io/en/doc/latest/book/box/data_model/
 
     Return values: `true` if no error, otherwise return `nil, err`
 
-Additionally when a section `sharding_key` is not empty in YAML schema call of
-function `ddl.set_schema(schema)` creates a space `_ddl_sharding_key` with two
+Call of function `ddl.set_schema(schema)` creates a space `_ddl_sharding_key` with two
 fields: `space_name` with type `string` and `sharding_key` with type `array`.
 
 ### Check compatibility


### PR DESCRIPTION
Space `_ddl_sharding_key` and it's format are a part of DDL API.
Users may use DDL spaces even no sharding keys or sharding spaces
are defined in DDL schema, so we need always create `_ddl_sharding_key`.
This behavior tested in `set_sharding_key.test_no_sharding_spaces`.