### PR TITLE
test: define test space format once

### DIFF
--- a/test/bucket_id_test.lua
+++ b/test/bucket_id_test.lua
@@ -9,32 +9,6 @@ local helper = require('test.helper')
 local REFERENCE_KEY = {1, 2, 3}
 local REFERENCE_BUCKET_ID = 4018458701
 
-local test_space = {
-    engine = 'memtx',
-    is_local = true,
-    temporary = false,
-    format = {
-        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
-        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
-        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
-        {name = 'integer_nullable', type = 'integer', is_nullable = true},
-        {name = 'number_nonnull', type = 'number', is_nullable = false},
-        {name = 'number_nullable', type = 'number', is_nullable = true},
-        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
-        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
-        {name = 'string_nonnull', type = 'string', is_nullable = false},
-        {name = 'string_nullable', type = 'string', is_nullable = true},
-        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
-        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
-        {name = 'array_nonnull', type = 'array', is_nullable = false},
-        {name = 'array_nullable', type = 'array', is_nullable = true},
-        {name = 'map_nonnull', type = 'map', is_nullable = false},
-        {name = 'map_nullable', type = 'map', is_nullable = true},
-        {name = 'any_nonnull', type = 'any', is_nullable = false},
-        {name = 'any_nullable', type = 'any', is_nullable = true},
-    },
-}
-
 local primary_index = {
     type = 'HASH',
     unique = true,
@@ -57,7 +31,13 @@ g.before_all(db.init)
 g.before_each(function()
     db.drop_all()
 
-    g.space = table.deepcopy(test_space)
+    g.space = {
+        engine = 'memtx',
+        is_local = true,
+        temporary = false,
+        format = table.deepcopy(helper.test_space_format())
+    }
+
     table.insert(g.space.format, 1, {
         name = 'bucket_id', type = 'unsigned', is_nullable = false
     })

--- a/test/check_schema_test.lua
+++ b/test/check_schema_test.lua
@@ -5,45 +5,27 @@ local db = require('test.db')
 local ddl_check = require('ddl.check')
 local ddl = require('ddl')
 
+local helper = require('test.helper')
+
 local g = t.group()
 g.before_all(db.init)
 g.before_each(db.drop_all)
+
+local space_format = helper.test_space_format()
+table.insert(space_format, {name = 'decimal_nonnull', type = 'decimal', is_nullable = false})
+table.insert(space_format, {name = 'decimal_null', type = 'decimal', is_nullable = true})
+table.insert(space_format, {name = 'double_nonnull', type = 'double', is_nullable = false})
+table.insert(space_format, {name = 'double_null', type = 'double', is_nullable = true})
+table.insert(space_format, {name = 'uuid_nonnull', type = 'uuid', is_nullable = false})
+table.insert(space_format, {name = 'uuid_null', type = 'uuid', is_nullable = true})
+table.insert(space_format, {name = 'annotated', type = 'any', is_nullable = true, comment = 'x'})
 
 local test_space = {
     engine = 'memtx',
     is_local = true,
     temporary = false,
-    format = {
-        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
-        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
-        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
-        {name = 'integer_nullable', type = 'integer', is_nullable = true},
-        {name = 'number_nonnull', type = 'number', is_nullable = false},
-        {name = 'number_nullable', type = 'number', is_nullable = true},
-        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
-        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
-        {name = 'string_nonnull', type = 'string', is_nullable = false},
-        {name = 'string_nullable', type = 'string', is_nullable = true},
-        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
-        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
-        {name = 'array_nonnull', type = 'array', is_nullable = false},
-        {name = 'array_nullable', type = 'array', is_nullable = true},
-        {name = 'map_nonnull', type = 'map', is_nullable = false},
-        {name = 'map_nullable', type = 'map', is_nullable = true},
-        {name = 'any_nonnull', type = 'any', is_nullable = false},
-        {name = 'any_nullable', type = 'any', is_nullable = true},
-        ---------------------------------------------------------
-        {name = 'decimal_nonnull', type = 'decimal', is_nullable = false},
-        {name = 'decimal_null', type = 'decimal', is_nullable = true},
-        {name = 'double_nonnull', type = 'double', is_nullable = false},
-        {name = 'double_null', type = 'double', is_nullable = true},
-        {name = 'uuid_nonnull', type = 'uuid', is_nullable = false},
-        {name = 'uuid_null', type = 'uuid', is_nullable = true},
-
-        {name = 'annotated', type = 'any', is_nullable = true, comment = 'x'},
-    },
+    format = space_format
 }
-
 
 local test_indexes = {{
         type = 'HASH',

--- a/test/check_sharding_metadata_test.lua
+++ b/test/check_sharding_metadata_test.lua
@@ -5,31 +5,14 @@ local db = require('test.db')
 local ddl = require('ddl')
 local ffi = require('ffi')
 
+local helper = require('test.helper')
+
 local g = t.group()
 local test_space = {
     engine = 'memtx',
     is_local = true,
     temporary = false,
-    format = {
-        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
-        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
-        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
-        {name = 'integer_nullable', type = 'integer', is_nullable = true},
-        {name = 'number_nonnull', type = 'number', is_nullable = false},
-        {name = 'number_nullable', type = 'number', is_nullable = true},
-        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
-        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
-        {name = 'string_nonnull', type = 'string', is_nullable = false},
-        {name = 'string_nullable', type = 'string', is_nullable = true},
-        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
-        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
-        {name = 'array_nonnull', type = 'array', is_nullable = false},
-        {name = 'array_nullable', type = 'array', is_nullable = true},
-        {name = 'map_nonnull', type = 'map', is_nullable = false},
-        {name = 'map_nullable', type = 'map', is_nullable = true},
-        {name = 'any_nonnull', type = 'any', is_nullable = false},
-        {name = 'any_nullable', type = 'any', is_nullable = true},
-    },
+    format = helper.test_space_format(),
 }
 
 local primary_index = {

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -1,5 +1,7 @@
 require('strict').on()
 
+local db = require('test.db')
+
 local fio = require('fio')
 local digest = require('digest')
 local helpers = table.copy(require('luatest').helpers)
@@ -18,6 +20,36 @@ fio.tempdir = function(base)
         fio.mktree(path)
         return path
     end
+end
+
+function helpers.test_space_format()
+    local space_format = {
+        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
+        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
+        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
+        {name = 'integer_nullable', type = 'integer', is_nullable = true},
+        {name = 'number_nonnull', type = 'number', is_nullable = false},
+        {name = 'number_nullable', type = 'number', is_nullable = true},
+        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
+        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
+        {name = 'string_nonnull', type = 'string', is_nullable = false},
+        {name = 'string_nullable', type = 'string', is_nullable = true},
+        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
+        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
+        {name = 'array_nonnull', type = 'array', is_nullable = false},
+        {name = 'array_nullable', type = 'array', is_nullable = true},
+        {name = 'map_nonnull', type = 'map', is_nullable = false},
+        {name = 'map_nullable', type = 'map', is_nullable = true},
+        {name = 'any_nonnull', type = 'any', is_nullable = false},
+        {name = 'any_nullable', type = 'any', is_nullable = true},
+    }
+
+    if db.v(2, 2) then
+        table.insert(space_format, {name = 'varbinary_nonnull', type = 'varbinary', is_nullable = false})
+        table.insert(space_format, {name = 'varbinary_nullable', type = 'varbinary', is_nullable = true})
+    end
+
+    return table.deepcopy(space_format)
 end
 
 function helpers.entrypoint(name)

--- a/test/set_schema_test.lua
+++ b/test/set_schema_test.lua
@@ -5,38 +5,14 @@ local db = require('test.db')
 local ddl = require('ddl')
 local log = require('log')
 
+local helper = require('test.helper')
+
 local g = t.group()
 g.before_all(db.init)
 g.before_each(db.drop_all)
 
 local function init_test_data()
-    local space_format = {
-        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
-        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
-        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
-        {name = 'integer_nullable', type = 'integer', is_nullable = true},
-        {name = 'number_nonnull', type = 'number', is_nullable = false},
-        {name = 'number_nullable', type = 'number', is_nullable = true},
-        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
-        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
-        {name = 'string_nonnull', type = 'string', is_nullable = false},
-        {name = 'string_nullable', type = 'string', is_nullable = true},
-        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
-        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
-        {name = 'array_nonnull', type = 'array', is_nullable = false},
-        {name = 'array_nullable', type = 'array', is_nullable = true},
-        {name = 'map_nonnull', type = 'map', is_nullable = false},
-        {name = 'map_nullable', type = 'map', is_nullable = true},
-        {name = 'any_nonnull', type = 'any', is_nullable = false},
-        {name = 'any_nullable', type = 'any', is_nullable = true},
-        {name = 'varbinary_nonnull', type = 'varbinary', is_nullable = false},
-        {name = 'varbinary_nullable', type = 'varbinary', is_nullable = true},
-    }
-
-    if not db.v(2, 2) then
-        space_format[19] = nil
-        space_format[20] = nil
-    end
+    local space_format = helper.test_space_format()
 
     return {
         ['test'] = {

--- a/test/set_sharding_metadata_test.lua
+++ b/test/set_sharding_metadata_test.lua
@@ -5,31 +5,14 @@ local db = require('test.db')
 local ddl = require('ddl')
 local ffi = require('ffi')
 
+local helper = require('test.helper')
+
 local g = t.group()
 local test_space = {
     engine = 'memtx',
     is_local = true,
     temporary = false,
-    format = {
-        {name = 'unsigned_nonnull', type = 'unsigned', is_nullable = false},
-        {name = 'unsigned_nullable', type = 'unsigned', is_nullable = true},
-        {name = 'integer_nonnull', type = 'integer', is_nullable = false},
-        {name = 'integer_nullable', type = 'integer', is_nullable = true},
-        {name = 'number_nonnull', type = 'number', is_nullable = false},
-        {name = 'number_nullable', type = 'number', is_nullable = true},
-        {name = 'boolean_nonnull', type = 'boolean', is_nullable = false},
-        {name = 'boolean_nullable', type = 'boolean', is_nullable = true},
-        {name = 'string_nonnull', type = 'string', is_nullable = false},
-        {name = 'string_nullable', type = 'string', is_nullable = true},
-        {name = 'scalar_nonnull', type = 'scalar', is_nullable = false},
-        {name = 'scalar_nullable', type = 'scalar', is_nullable = true},
-        {name = 'array_nonnull', type = 'array', is_nullable = false},
-        {name = 'array_nullable', type = 'array', is_nullable = true},
-        {name = 'map_nonnull', type = 'map', is_nullable = false},
-        {name = 'map_nullable', type = 'map', is_nullable = true},
-        {name = 'any_nonnull', type = 'any', is_nullable = false},
-        {name = 'any_nullable', type = 'any', is_nullable = true},
-    },
+    format = helper.test_space_format(),
 }
 
 local primary_index = {


### PR DESCRIPTION
Now every test file defines it's own test space format. However all
these formats are similar and we can define once in helpers to avoid
code duplication.