### PR TITLE
test: shuffle tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,10 @@ find_package(LuaCovCoveralls)
 
 set(CODE_COVERAGE_REPORT "${PROJECT_SOURCE_DIR}/luacov.report.out")
 set(CODE_COVERAGE_STATS "${PROJECT_SOURCE_DIR}/luacov.stats.out")
+string(RANDOM ALPHABET 0123456789 seed)
 
 add_custom_target(luatest
-  COMMAND ${LUATEST} -v --coverage
+  COMMAND ${LUATEST} -v --coverage --shuffle all:${seed}
   BYPRODUCTS ${CODE_COVERAGE_STATS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Run regression tests"

--- a/test/set_sharding_metadata_test.lua
+++ b/test/set_sharding_metadata_test.lua
@@ -154,8 +154,12 @@ function g.test_two_sharding_spaces()
     space_two.sharding_key = {
         'unsigned_nonnull', 'integer_nonnull', 'string_nonnull'
     }
-    local sharding_func_name = 'some_module.sharding_func'
-    rawset(_G, sharding_func_name, function(key) return key end)
+    local some_module = {
+        sharding_func = function(key) return key end
+    }
+    local sharding_func_module = 'some_module'
+    local sharding_func_name = sharding_func_module .. '.sharding_func'
+    rawset(_G, sharding_func_module, some_module)
     space_two.sharding_func = sharding_func_name
 
     local schema = {
@@ -195,7 +199,7 @@ function g.test_two_sharding_spaces()
     local ddl_schema = ddl.get_schema()
     t.assert_equals(ddl_schema, schema)
     -- remove test data
-    rawset(_G, sharding_func_name, nil)
+    rawset(_G, sharding_func_module, nil)
 end
 
 function g.test_apply_sequently()
@@ -286,8 +290,9 @@ function g.test_ddl_sharding_func_dot_notation()
     local some_module = {
         sharding_func = function(key) return key end
     }
-    local user_sharding_func_name = 'some_module.sharding_func'
-    rawset(_G, 'some_module', some_module)
+    local sharding_func_module = 'some_module'
+    local user_sharding_func_name = sharding_func_module .. '.sharding_func'
+    rawset(_G, sharding_func_module, some_module)
 
     local space_one = table.deepcopy(g.space)
     space_one.sharding_func = user_sharding_func_name
@@ -319,7 +324,7 @@ function g.test_ddl_sharding_func_dot_notation()
     local ddl_schema = ddl.get_schema()
     t.assert_equals(ddl_schema, schema)
     -- remove test data
-    rawset(_G, user_sharding_func_name, nil)
+    rawset(_G, sharding_func_module, nil)
 end
 
 function g.test_ddl_user_sharding_function_call()


### PR DESCRIPTION
luatest has an option --shuffle that allows to randomise the order of
tests. This can be useful to detect a test that passes just because it
happens to run after an unrelated test that leaves the system in a
favourable state. Patch enable tests shuffling with predefined random
seed generated by CMake [1]. Seed is useful for reproducing a problems
related to the specific test order.

https://cmake.org/cmake/help/latest/command/string.html#random