### PR TITLE
fix: check for vshard sharding func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix check for vshard sharding funcs (#91).
+
 ## [1.6.1] - 2022-06-21
 
 ### Added

--- a/ddl/check.lua
+++ b/ddl/check.lua
@@ -1,6 +1,11 @@
 local utils = require('ddl.utils')
 local db = require('ddl.db')
 
+local vshard_func_support = {
+    ['vshard.router.bucket_id_mpcrc32'] = true,
+    ['vshard.router.bucket_id_strcrc32'] = true
+}
+
 local function check_field(i, field, space)
     if type(field) ~= 'table' then
         return nil, string.format(
@@ -735,7 +740,7 @@ local function check_sharding_func_name(sharding_func_name)
         return is_callable(sharding_func)
     end
 
-    return false
+    return vshard_func_support[sharding_func_name]
 end
 
 local function check_sharding_func(space)

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -100,4 +100,26 @@ function helpers.sharding_func(shard_key_1, shard_key_2)
     end
 end
 
+function helpers.prepare_schema(g, test_space, primary_index, bucket_id_idx, test_opts)
+    db.drop_all()
+
+    local opts = test_opts or {}
+    opts = table.deepcopy(opts)
+
+    g.space = table.deepcopy(test_space)
+    table.insert(g.space.format, 1, {
+        name = 'bucket_id', type = 'unsigned', is_nullable = false
+    })
+
+    g.space.indexes = {
+        table.deepcopy(primary_index),
+        table.deepcopy(bucket_id_idx)
+    }
+    g.space.sharding_key = opts.sharding_key
+    g.space.sharding_func = opts.sharding_func
+    g.schema = {spaces = {
+        space = g.space,
+    }}
+end
+
 return helpers


### PR DESCRIPTION
`ddl.set_schema(schema)` fails with schema containing `vshard` sharding func.
It doesn't matter if vshard module was required on ddl storage.
The problem is that checking sharding function in dot notation
is performed by checking each item separated by dot in sharding
function name, item should be contained in global environment `_G`.
But in vshard sharding function case item `routers` (field in `vshard` table)
is an empty table because we store schema info on storage.
So field `bucket_id_strcrc32` is nil in 'vshard.router.bucket_id_strcrc32'.
Solution is to treat vshard sharding functions as separate cases.

Closes #91