### PR TITLE
ci: add reusable testing workflow for ddl module

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -1,0 +1,42 @@
+name: Reusable test
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the Tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Clone the ddl module
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository_owner }}/ddl
+
+      - name: Download the Tarantool build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      # All dependencies for tarantool are already installed in Ubuntu 20.04.
+      # Check package dependencies when migrating to other OS version.
+      - name: Install Tarantool
+        run: |
+          sudo dpkg -i tarantool_*.deb tarantool-common_*.deb tarantool-dev_*.deb
+          tarantool --version
+
+      - name: Install requirements
+        run: ./deps.sh
+
+      - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
+
+      - run: cmake -S . -B build
+
+      - name: Run regression tests
+        run: make -C build luatest-no-coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ add_custom_target(luatest
   COMMENT "Run regression tests"
 )
 
+add_custom_target(luatest-no-coverage
+  COMMAND ${LUATEST} -v --shuffle all:${seed}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Run regression tests without coverage"
+)
+
 add_custom_target(coverage
   COMMAND ${LUACOV} ${PROJECT_SOURCE_DIR} && grep -A999 '^Summary' ${CODE_COVERAGE_REPORT}
   DEPENDS ${CODE_COVERAGE_STATS}


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
ddl module with an arbitrary tarantool version.

Tested [here](https://github.com/tarantool/tarantool/actions/runs/3752256684)
Tested negatively [here](https://github.com/tarantool/tarantool/actions/runs/3752394234)

Part of tarantool/tarantool#6619