### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'ddl'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -18,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added versioning support (#105).
+
 ### Changed
 
 ### Fixed

--- a/ddl.lua
+++ b/ddl.lua
@@ -188,4 +188,5 @@ return {
     set_schema = set_schema,
     get_schema = get_schema,
     bucket_id = bucket_id,
+    _VERSION = require('ddl.version'),
 }

--- a/ddl/version.lua
+++ b/ddl/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '1.6.2'


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204