### PR TITLE
ci: workaround setup-tarantool problem with Jammy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,13 @@ jobs:
         include:
           - tarantool: '2.8'
             coveralls: true
-    runs-on: [ubuntu-latest]
+    # There are problems with current version of the
+    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
+    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
+    # will be resolved. See [1] for details.
+    #
+    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1
@@ -71,7 +77,13 @@ jobs:
       fail-fast: false
       matrix:
         tarantool: ['1.10', '2.5', '2.6', '2.7']
-    runs-on: [ubuntu-latest]
+    # There are problems with current version of the
+    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
+    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
+    # will be resolved. See [1] for details.
+    #
+    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - uses: tarantool/setup-tarantool@v1


### PR DESCRIPTION
There is known unsolved problem with Ubuntu Jammy [1].  Because of this, `tarantool 2.6` is installed in all cases. During tests it turns out that `builtin#95 table.clear` is [nil](https://github.com/tarantool/ddl/actions/runs/4518349665/jobs/7958166174#step:15:3) on the installed tarantool 2.6, which causes problems in ci job `test`.

Also the expected tarantool version was not installed in job `benchmark` before this patch.

1. tarantool/setup-tarantool/issues/36