### PR TITLE
Basic fieldno path support for indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Add basic fieldno path support for indexes (#108).
+  It is the compatibility layer for Tarantool spaces created not through ddl:
+  users are not encouraged to create fieldno path indexes in schema,
+  since we do not support them as sharding keys.
+
 ## [1.6.2] - 2022-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.3] - 2023-06-08
 
 ### Added
 

--- a/ddl.lua
+++ b/ddl.lua
@@ -137,11 +137,6 @@ local function _set_schema(schema)
 end
 
 local function set_schema(schema)
-    local ok, err = check_schema_format(schema)
-    if not ok then
-        return nil, err
-    end
-
     local ok, err = check_schema(schema)
     if not ok then
         return nil, err

--- a/ddl/version.lua
+++ b/ddl/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.6.2'
+return '1.6.3'


### PR DESCRIPTION
It is the compatibility layer for Tarantool spaces created not through ddl: users are not encouraged to create fieldno path indexes in ddl schema explicitly, since we do not support them as sharding keys.

Closes #108