### PR TITLE
ddl: add exclude_null support for indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added exclude_null support for indexes (#110).
+
 ## [1.6.3] - 2023-06-08
 
 ### Added

--- a/ddl/db.lua
+++ b/ddl/db.lua
@@ -112,6 +112,10 @@ local function transactional_ddl_allowed()
     return tarantool_version_at_least(2, 2)
 end
 
+local function exclude_null_allowed()
+    return tarantool_version_at_least(2, 8, 1)
+end
+
 
 local function atomic_tail(status, ...)
     if not status then
@@ -151,6 +155,7 @@ return {
     multikey_path_allowed = multikey_path_allowed,
     transactional_ddl_allowed = transactional_ddl_allowed,
     datetime_allowed = datetime_allowed,
+    exclude_null_allowed = exclude_null_allowed,
 
     call_atomic = call_atomic,
     call_dry_run = call_dry_run,

--- a/ddl/set.lua
+++ b/ddl/set.lua
@@ -9,6 +9,7 @@ local function create_index(box_space, ddl_index)
             ddl_index_part.path, ddl_index_part.type,
             is_nullable = ddl_index_part.is_nullable,
             collation = ddl_index_part.collation,
+            exclude_null = ddl_index_part.exclude_null,
         }
         table.insert(index_parts, index_part)
     end


### PR DESCRIPTION
Add exclude_null support for indexes. The option was introduced in Tarantool 2.8.1 [1] for nullable TREE indexes.

Since ddl approach is "require explicit fields rather than fill with sane defaults" (for example, one must explicitly set is_nullable for each field), we do not add "if exclude_null=true and is_nullable is not provided, set is_nullable=true" rule from the core Tarantool [1]: we require to explicitly specify both fields, if one wants to use exclude_null features.

1. https://github.com/tarantool/tarantool/commit/17c9c034933d726925910ce5bf8b20e8e388f6e3

Closes #110