### PR TITLE
ci: fix luatest version

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -4,6 +4,6 @@
 set -e
 
 # Test dependencies:
-tarantoolctl rocks install luatest 0.5.7
+tarantoolctl rocks install luatest
 tarantoolctl rocks install luacov 0.13.0
 tarantoolctl rocks install luacheck 0.26.0


### PR DESCRIPTION
"Test" workflow installs latest luatest, yet "Reusable test" installs luatest 0.5.7. Latest e2cdb560 commit had introduced tests which use some luatest master utils. These tests fails on "Reusable test", see [1].

1. https://github.com/tarantool/tarantool/actions/runs/5411519721/jobs/9835738155

Follows #110