### PR TITLE
ddl: support interval type in format

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,11 +36,19 @@ jobs:
         with:
           tarantool-version: '2.11'
 
+      - name: Prepare apt repo
+        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+
+      - name: Install tt cli
+        run: sudo apt install -y tt
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
       # Make a release
       - run: echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV
-      - run: tarantoolctl rocks new_version --tag ${{ env.TAG }}
-      - run: tarantoolctl rocks install ddl-${{ env.TAG }}-1.rockspec
-      - run: tarantoolctl rocks pack ddl ${{ env.TAG }}
+      - run: tt rocks new_version --tag ${{ env.TAG }}
+      - run: tt rocks install ddl-${{ env.TAG }}-1.rockspec
+      - run: tt rocks pack ddl ${{ env.TAG }}
 
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -31,10 +31,10 @@ jobs:
     needs: version-check
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v4
+      - uses: tarantool/setup-tarantool@v2
         with:
-          tarantool-version: '2.5'
+          tarantool-version: '2.11'
 
       # Make a release
       - run: echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,34 +28,35 @@ jobs:
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
+      - name: Prepare apt repo
+        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+
+      - name: Install tt cli
+        run: sudo apt install -y tt
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
       # Setup luatest and luacheck
       - name: Cache rocks
         uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/
-          key: cache-rocks-${{ matrix.runs-on }}-06
-      -
-        run: tarantoolctl rocks install luacheck
+          key: cache-rocks-${{ matrix.runs-on }}-07
+
+      - name: Install test dependencies
+        run: ./deps.sh
         if: steps.cache-rocks.outputs.cache-hit != 'true'
-      -
-        run: tarantoolctl rocks install luatest
-        if: steps.cache-rocks.outputs.cache-hit != 'true'
-      -
-        run: tarantoolctl rocks install luacov
-        if: steps.cache-rocks.outputs.cache-hit != 'true'
-      -
-        run: tarantoolctl rocks install luacov-coveralls 0.2.3-1 --server=https://luarocks.org
-        if: steps.cache-rocks.outputs.cache-hit != 'true'
+      
       - run: echo $PWD/.rocks/bin >> $GITHUB_PATH
 
-      - run: tarantoolctl rocks list
-      - run: tarantoolctl rocks install cartridge
+      - run: tt rocks list
+      - run: tt rocks install cartridge
         env:
           CMAKE_DUMMY_WEBUI: true
-      - run: tarantoolctl rocks remove ddl --force
+      - run: tt rocks remove ddl --force
 
-      - run: tarantoolctl rocks make
+      - run: tt rocks make
       - run: cmake -S . -B build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,8 +72,8 @@ jobs:
         if: ${{ matrix.coveralls }}
 
       # Cleanup cached paths
-      - run: tarantoolctl rocks remove cartridge
-      - run: tarantoolctl rocks remove ddl
+      - run: tt rocks remove cartridge
+      - run: tt rocks remove ddl
   benchmark:
     strategy:
       fail-fast: false
@@ -92,6 +93,14 @@ jobs:
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
+      - name: Prepare apt repo
+        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+
+      - name: Install tt cli
+        run: sudo apt install -y tt
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
       # Setup luatest
       - name: Cache rocks
         uses: actions/cache@v3
@@ -100,7 +109,7 @@ jobs:
           path: .rocks/
           key: cache-rocks-${{ matrix.runs-on }}-bench-01
 
-      - run: tarantoolctl rocks install luatest
+      - run: tt rocks install luatest
         if: steps.cache-rocks.outputs.cache-hit != 'true'
 
       - run: tarantool ./test/bench_cache.lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7']
+        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8', '2.10']
         coveralls: [false]
         include:
-          - tarantool: '2.8'
+          - tarantool: '2.11'
             coveralls: true
     # There are problems with current version of the
     # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
@@ -22,14 +22,15 @@ jobs:
     # [1]: https://github.com/tarantool/setup-tarantool/issues/36
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v4
+
+      - uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
       # Setup luatest and luacheck
       - name: Cache rocks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/
@@ -76,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7']
+        tarantool: ['2.11']
     # There are problems with current version of the
     # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
     # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
@@ -85,14 +86,15 @@ jobs:
     # [1]: https://github.com/tarantool/setup-tarantool/issues/36
     runs-on: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: tarantool/setup-tarantool@v1
+      - uses: actions/checkout@v4
+
+      - uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
       # Setup luatest
       - name: Cache rocks
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-rocks
         with:
           path: .rocks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support of `interval` type for Tarantool 2.10+ space format.
+
 ## [1.6.4] - 2023-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ format = {
                     type = 'unsigned' | 'string' | 'varbinary' |
                             'integer' | 'number' | 'boolean' |
                             'array' | 'scalar' | 'any' | 'map' |
-                            'decimal' | 'double' | 'uuid' | 'datetime'
+                            'decimal' | 'double' | 'uuid' | 'datetime' |
+                            'interval'
                 },
                 ...
             },

--- a/ddl/check.lua
+++ b/ddl/check.lua
@@ -59,6 +59,7 @@ local function check_field(i, field, space)
             double    = true,
             uuid      = true,
             datetime  = true,
+            interval  = true,
         }
 
         if known_field_types[field.type] == nil then
@@ -78,6 +79,13 @@ local function check_field(i, field, space)
         if not db.datetime_allowed() and field.type == 'datetime' then
             return nil, string.format(
                 "spaces[%q].format[%q].type: datetime type isn't allowed in your Tarantool version (%s)",
+                space.name, field.name, _TARANTOOL
+            )
+        end
+
+        if not db.interval_allowed() and field.type == 'interval' then
+            return nil, string.format(
+                "spaces[%q].format[%q].type: interval type isn't allowed in your Tarantool version (%s)",
                 space.name, field.name, _TARANTOOL
             )
         end
@@ -214,6 +222,17 @@ local function check_index_part_type(part_type, index_type)
         uuid = true,
         datetime = true,
     }
+
+    local known_unsupported_part_types = {
+        interval = true,
+    }
+
+    if known_unsupported_part_types[part_type] then
+        return nil, string.format(
+            "%s field type is unsupported in indexes",
+            part_type
+        )
+    end
 
     if not known_part_types[part_type] then
         return nil, string.format(

--- a/ddl/db.lua
+++ b/ddl/db.lua
@@ -107,6 +107,10 @@ local function datetime_allowed()
     return tarantool_version_at_least(2, 10)
 end
 
+local function interval_allowed()
+    return tarantool_version_at_least(2, 10)
+end
+
 -- https://github.com/tarantool/tarantool/issues/4083
 local function transactional_ddl_allowed()
     return tarantool_version_at_least(2, 2)
@@ -155,6 +159,7 @@ return {
     multikey_path_allowed = multikey_path_allowed,
     transactional_ddl_allowed = transactional_ddl_allowed,
     datetime_allowed = datetime_allowed,
+    interval_allowed = interval_allowed,
     exclude_null_allowed = exclude_null_allowed,
 
     call_atomic = call_atomic,

--- a/deps.sh
+++ b/deps.sh
@@ -3,7 +3,30 @@
 
 set -e
 
+if ! [ -x "$(command -v tt)" ]; then
+	TTCTL=tarantoolctl
+else
+	TTCTL=tt
+fi
+
 # Test dependencies:
-tarantoolctl rocks install luatest
-tarantoolctl rocks install luacov 0.13.0
-tarantoolctl rocks install luacheck 0.26.0
+$TTCTL rocks install luatest
+$TTCTL rocks install luacov 0.13.0
+$TTCTL rocks install luacheck 0.26.0
+
+$TTCTL rocks install https://raw.githubusercontent.com/mpeterv/cluacov/master/cluacov-scm-1.rockspec
+$TTCTL rocks install https://raw.githubusercontent.com/LuaDist/dkjson/master/dkjson-2.5-2.rockspec
+$TTCTL rocks install https://raw.githubusercontent.com/keplerproject/luafilesystem/master/luafilesystem-scm-1.rockspec
+$TTCTL rocks install https://raw.githubusercontent.com/moteus/lua-path/master/rockspecs/lua-path-scm-0.rockspec
+
+# Most of this code is the workaround for
+# https://github.com/moteus/luacov-coveralls/pull/30
+# Remove it, when the pull request will be merged.
+TMPDIR="$(mktemp -d)"
+LUACOV_COVERALLS_ROCKSPEC_URL="https://raw.githubusercontent.com/moteus/luacov-coveralls/master/rockspecs/luacov-coveralls-scm-0.rockspec"
+LUACOV_COVERALLS_ROCKSPEC_FILE="${TMPDIR}/luacov-coveralls-scm-0.rockspec"
+curl -fsSL "${LUACOV_COVERALLS_ROCKSPEC_URL}" > "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+sed -i -e 's@git://@git+https://@' "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+$TTCTL rocks install "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+rm "${LUACOV_COVERALLS_ROCKSPEC_FILE}"
+rmdir "${TMPDIR}"

--- a/test/check_schema_test.lua
+++ b/test/check_schema_test.lua
@@ -199,6 +199,12 @@ function g.test_datetime_index_part_type()
     end
 end
 
+function g.test_interval_index_part_type()
+    local ok, err = ddl_check.check_index_part_type('interval', 'TREE')
+    t.assert_not(ok)
+    t.assert_equals(err, "interval field type is unsupported in indexes")
+end
+
 function g.test_index_part_path()
     local index_info = {type = 'HASH'}
 
@@ -1152,6 +1158,21 @@ function g.test_field()
         t.assert_not(ok)
         t.assert_equals(err, string.format(
             [[spaces["space"].format["x"].type: datetime type ]] ..
+            [[isn't allowed in your Tarantool version (%s)]],
+            _TARANTOOL
+        ))
+    end
+
+    local ok, err = ddl_check.check_field(
+        1, {name = 'x', type = 'interval', is_nullable = false}, space_info
+    )
+    if db.v(2, 10) then
+        t.assert(ok)
+        t.assert_not(err)
+    else
+        t.assert_not(ok)
+        t.assert_equals(err, string.format(
+            [[spaces["space"].format["x"].type: interval type ]] ..
             [[isn't allowed in your Tarantool version (%s)]],
             _TARANTOOL
         ))

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -54,6 +54,11 @@ function helpers.test_space_format()
         table.insert(space_format, {name = 'datetime_nullable', type = 'datetime', is_nullable = true})
     end
 
+    if db.v(2, 10) then
+        table.insert(space_format, {name = 'interval_nonnull', type = 'interval', is_nullable = false})
+        table.insert(space_format, {name = 'interval_nullable', type = 'interval', is_nullable = true})
+    end
+
     return table.deepcopy(space_format)
 end
 


### PR DESCRIPTION
Datetime intervals are supported as a part of space schema format since 2.10.0 [1]. They are not allowed to be a part of memtx index [2].

1. https://github.com/tarantool/tarantool/commit/a9e30fb365c1643484054aa07038c015383e7faa
2. https://github.com/tarantool/tarantool/blob/ddaa5a320ee8d8d1009e07bbf6b8fe5cb4acbb45/src/box/memtx_space.c#L844-L851