### PR TITLE
release 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.6.5] - 2023-10-23
 
 ### Added
 
-- Added support of `interval` type for Tarantool 2.10+ space format.
+- Added support of `interval` type for Tarantool 2.10+ space format (#117).
 
 ## [1.6.4] - 2023-07-05
 

--- a/ddl/version.lua
+++ b/ddl/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.6.4'
+return '1.6.5'


### PR DESCRIPTION
## Overview

This is a patch release introducing datetime intervals support in the format.

## New features
- Added support of `interval` type for Tarantool 2.10+ space format (#117).