### PR TITLE
ddl: support sequences

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,6 @@
 redefined = false
+globals = {"box", "_TARANTOOL", "tonumber64", "utf8", "table"}
 include_files = {"**/*.lua", "*.rockspec", "*.luacheckrc"}
 exclude_files = {".rocks/", "tmp/", ".history/"}
 max_line_length = 120
+max_comment_line_length = 150

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support of sequences in schema and space indexes (#122).
+
 ## [1.6.5] - 2023-10-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -205,17 +205,16 @@ format = {
         },
         ...
     },
-    sequences = { -- Not implemented yet
-        [seqence_name] = {
-            start
-            min
-            max
-            cycle
-            cache
-            step
-
-        }
-    }
+    sequences = {
+        [sequence_name] = {
+            start = start,
+            min = min,
+            max = max,
+            cycle = cycle,
+            cache = cache,
+            step = step,
+        },
+    },
 }
 ```
 
@@ -292,8 +291,52 @@ local schema = {
             }},
             sharding_key = {'customer_id'},
             sharding_func = 'vshard.router.bucket_id_mpcrc32',
-        }
-    }
+        },
+        tickets = {
+            engine = 'memtx',
+            is_local = false,
+            temporary = false,
+            format = {
+                {name = 'ticket_id', is_nullable = false, type = 'unsigned'},
+                {name = 'customer_id', is_nullable = false, type = 'unsigned'},
+                {name = 'bucket_id', is_nullable = false, type = 'unsigned'},
+                {name = 'contents', is_nullable = false, type = 'string'},
+            },
+            indexes = {{
+                name = 'ticket_id',
+                type = 'TREE',
+                unique = true,
+                parts = {
+                    {path = 'ticket_id', is_nullable = false, type = 'unsigned'}
+                },
+                sequence = 'ticket_seq',
+            }, {,
+                name = 'customer_id',
+                type = 'TREE',
+                unique = false,
+                parts = {
+                    {path = 'customer_id', is_nullable = false, type = 'unsigned'}
+                }
+            }, {
+                name = 'bucket_id',
+                type = 'TREE',
+                unique = false,
+                parts = {
+                    {path = 'bucket_id', is_nullable = false, type = 'unsigned'}
+                }
+            }},
+            sharding_key = {'customer_id'},
+            sharding_func = 'vshard.router.bucket_id_mpcrc32',
+        },
+    },
+    sequences = {
+        ticket_seq = {
+            start = 1,
+            min = 1,
+            max = 10000,
+            cycle = false,
+        },
+    },
 }
 ```
 

--- a/ddl/compare.lua
+++ b/ddl/compare.lua
@@ -1,0 +1,40 @@
+local INT64_MIN = tonumber64('-9223372036854775808')
+local INT64_MAX = tonumber64('9223372036854775807')
+
+local function get_sequence_defaults(opts)
+    -- https://github.com/tarantool/tarantool/blob/05e69108076ae22f33f8fc55b463c6babb6478fe/src/box/lua/schema.lua#L2847-L2855
+    local ascending = not opts.step or opts.step > 0
+    return {
+        step = 1,
+        min = ascending and 1 or INT64_MIN,
+        max = ascending and INT64_MAX or -1,
+        start = ascending and (opts.min or 1) or (opts.max or -1),
+        cache = 0,
+        cycle = false,
+    }
+end
+
+local function assert_equiv_sequence_schema(sequence_schema, current_schema)
+    local defaults = get_sequence_defaults(sequence_schema)
+
+    for key, current_value in pairs(current_schema) do
+        local ddl_value = sequence_schema[key]
+
+        if ddl_value ~= nil then
+            if ddl_value ~= current_value then
+                return nil, ('%s (expected %s, got %s)'):format(key, current_value, ddl_value)
+            end
+        else
+            local default_value = defaults[key]
+            if default_value ~= current_value then
+                return nil, ('%s (expected %s, got nil and default is %s)'):format(key, current_value, default_value)
+            end
+        end
+    end
+
+    return true
+end
+
+return {
+    assert_equiv_sequence_schema = assert_equiv_sequence_schema,
+}

--- a/ddl/utils.lua
+++ b/ddl/utils.lua
@@ -49,12 +49,22 @@ local LUA_KEYWORDS = {
     ['while'] = true,
 }
 
+local function is_number(v)
+    local is_lua_number = type(v) == 'number'
+
+    local is_lj_uint = type(v) == 'cdata' and ffi.istype('uint64_t', v)
+    local is_lj_int = type(v) == 'cdata' and ffi.istype('int64_t', v)
+    local is_lj_number = is_lj_uint or is_lj_int
+
+    return is_lua_number or is_lj_number
+end
+
 local function deepcmp(got, expected, extra)
     if extra == nil then
         extra = {}
     end
 
-    if type(expected) == "number" or type(got) == "number" then
+    if is_number(expected) or is_number(got) then
         extra.got = got
         extra.expected = expected
         if got ~= got and expected ~= expected then
@@ -213,13 +223,25 @@ local function get_G_function(func_name)
     return sharding_func
 end
 
+local function concat_arrays(arr1, arr2)
+    local res = table.deepcopy(arr1)
+
+    for _, v in ipairs(arr2) do
+        table.insert(res, table.deepcopy(v))
+    end
+
+    return res
+end
+
 return {
     deepcmp = deepcmp,
     is_array = is_array,
+    is_number = is_number,
     redundant_key = redundant_key,
     find_first_duplicate = find_first_duplicate,
     lj_char_isident = lj_char_isident,
     lj_char_isdigit = lj_char_isdigit,
     LUA_KEYWORDS = LUA_KEYWORDS,
     get_G_function = get_G_function,
+    concat_arrays = concat_arrays,
 }

--- a/test/db.lua
+++ b/test/db.lua
@@ -16,10 +16,22 @@ local function init()
     }
 end
 
-local function drop_all()
+local function drop_all_non_system_spaces()
     for _, space in box.space._space:pairs({box.schema.SYSTEM_ID_MAX}, {iterator = "GT"}) do
         box.space[space.name]:drop()
     end
+end
+
+local function drop_all_sequences()
+    for _, seq in box.space._sequence:pairs() do
+        print(('dropping %q'):format(seq.name))
+        box.sequence[seq.name]:drop()
+    end
+end
+
+local function drop_all()
+    drop_all_non_system_spaces()
+    drop_all_sequences()
 end
 
 -- Check if tarantool version >= required

--- a/test/set_schema_test.lua
+++ b/test/set_schema_test.lua
@@ -117,10 +117,10 @@ function g.test_invalid_schema()
         'functions: not supported'
     )
 
-    local res, err = ddl.set_schema({spaces = {}, sequences = {}})
+    local res, err = ddl.set_schema({spaces = {}, sequences = true})
     t.assert_not(res)
     t.assert_equals(err,
-        'sequences: not supported'
+        'sequences: must be a table or nil, got boolean'
     )
 
     local res, err = ddl.set_schema({spaces = {}, meta = {}})

--- a/test/set_schema_with_sequence_test.lua
+++ b/test/set_schema_with_sequence_test.lua
@@ -1,0 +1,250 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local db = require('test.db')
+local ddl = require('ddl')
+local ddl_get = require('ddl.get')
+
+local g = t.group()
+g.before_all(db.init)
+g.before_each(db.drop_all)
+
+local seq_start = 1
+local seq_step = 5
+
+local test_schema = {
+    spaces = {
+        ['with_sequence'] = {
+            engine = 'memtx',
+            is_local = false,
+            temporary = false,
+            format = {
+                {name = 'seq_id', type = 'unsigned', is_nullable = false},
+                {name = 'first', type = 'string', is_nullable = false},
+                {name = 'second', type = 'string', is_nullable = false},
+            },
+            indexes = {
+                {
+                    name = 'seq_index',
+                    type = 'TREE',
+                    unique = true,
+                    parts = {
+                        {is_nullable = false, path = 'seq_id', type = 'unsigned'},
+                    },
+                    sequence = 'seq',
+                },
+            },
+        },
+    },
+    sequences = {
+        ['seq'] = {
+            start = seq_start,
+            min = 0,
+            max = 1000000000000ULL,
+            cycle = true,
+            cache = 0,
+            step = seq_step,
+        },
+    },
+}
+
+local function assert_test_schema_applied()
+    t.assert_not_equals(box.space['with_sequence'], nil, 'space exists')
+    t.assert_not_equals(box.space['with_sequence'].index['seq_index'], nil, 'space index exists')
+
+    local index_seq_id = box.space['with_sequence'].index['seq_index'].sequence_id
+    t.assert_type(index_seq_id, 'number', 'space index uses sequence')
+
+    local seq = box.sequence['seq']
+    t.assert_not_equals(seq, nil, 'sequence exists')
+    t.assert_equals(seq.start, seq_start, 'sequence is configured with proper values')
+    t.assert_equals(seq.min, 0, 'sequence is configured with proper values')
+    t.assert_equals(seq.max, 1000000000000ULL, 'sequence is configured with proper values')
+    t.assert_equals(seq.cycle, true, 'sequence is configured with proper values')
+    t.assert_equals(seq.cache, 0, 'sequence is configured with proper values')
+    t.assert_equals(seq.step, seq_step, 'sequence is configured with proper values')
+
+    local index_seq = ddl_get.get_sequence_by_id(index_seq_id)
+    t.assert_equals(seq, index_seq, 'index uses expected sequence')
+end
+
+local function assert_two_test_records_can_be_inserted(opts)
+    assert(type(opts.steps_before) == 'number')
+
+    local start_id = seq_start + opts.steps_before * seq_step
+
+    t.assert_equals(
+        box.space['with_sequence']:insert{box.NULL, 'val1', 'val2'},
+        {start_id, 'val1', 'val2'},
+        'autoincrement space works fine for inserts'
+    )
+    t.assert_equals(
+        box.space['with_sequence']:insert{box.NULL, 'val1', 'val2'},
+        {start_id + seq_step, 'val1', 'val2'},
+        'autoincrement space works fine for inserts'
+    )
+end
+
+g.test_sequence_index_schema_applies_on_clean_instance = function()
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_equals(err, nil)
+
+    assert_test_schema_applied()
+    assert_two_test_records_can_be_inserted{steps_before = 0}
+end
+
+g.test_sequence_index_schema_reapply = function()
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_equals(err, nil)
+
+    assert_test_schema_applied()
+    assert_two_test_records_can_be_inserted{steps_before = 0}
+
+    local _, err = ddl.set_schema(ddl.get_schema())
+    t.assert_equals(err, nil)
+
+    assert_test_schema_applied()
+    assert_two_test_records_can_be_inserted{steps_before = 2}
+end
+
+function g.test_sequence_index_schema_applies_if_same_setup_already_exists()
+    g.space = box.schema.space.create('with_sequence')
+    g.space:format({
+        {name = 'seq_id', type = 'unsigned', is_nullable = false},
+        {name = 'first', type = 'string', is_nullable = false},
+        {name = 'second', type = 'string', is_nullable = false},
+    })
+
+    local seq_name = 'seq'
+    local seq_opts = {
+        start = 1,
+        min = 0,
+        max = 1000000000000ULL,
+        cycle = true,
+        cache = 0,
+        step = 5,
+    }
+    box.schema.sequence.create(seq_name, seq_opts)
+
+    g.space:create_index('seq_index', {
+        type = 'TREE',
+        unique = true,
+        parts = {{is_nullable = false, field = 'seq_id', type = 'unsigned'}},
+        sequence = seq_name,
+    })
+
+    assert_two_test_records_can_be_inserted{steps_before = 0}
+
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_equals(err, nil)
+
+    assert_test_schema_applied()
+    assert_two_test_records_can_be_inserted{steps_before = 2}
+end
+
+function g.test_sequence_index_schema_apply_fails_if_existing_space_index_does_not_use_sequence()
+    g.space = box.schema.space.create('with_sequence')
+    g.space:format({
+        {name = 'seq_id', type = 'unsigned', is_nullable = false},
+        {name = 'first', type = 'string', is_nullable = false},
+        {name = 'second', type = 'string', is_nullable = false},
+    })
+
+    g.space:create_index('seq_index', {
+        type = 'TREE',
+        unique = true,
+        parts = {{is_nullable = false, field = 'seq_id', type = 'unsigned'}},
+        -- no sequence
+    })
+
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_str_contains(err, 'Incompatible schema: spaces["with_sequence"] //indexes/1/sequence ' ..
+                               '(expected nil, got string)')
+end
+
+function g.test_sequence_index_schema_apply_fails_if_existing_space_index_uses_different_sequence()
+    g.space = box.schema.space.create('with_sequence')
+    g.space:format({
+        {name = 'seq_id', type = 'unsigned', is_nullable = false},
+        {name = 'first', type = 'string', is_nullable = false},
+        {name = 'second', type = 'string', is_nullable = false},
+    })
+
+    box.schema.sequence.create('different_sequence')
+
+    g.space:create_index('seq_index', {
+        type = 'TREE',
+        unique = true,
+        parts = {{is_nullable = false, field = 'seq_id', type = 'unsigned'}},
+        sequence = 'different_sequence',
+    })
+
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_str_contains(err, 'Incompatible schema: spaces["with_sequence"] //indexes/1/sequence ' ..
+                               '(expected different_sequence, got seq)')
+end
+
+function g.test_sequence_schema_apply_fails_if_existing_sequence_has_different_options()
+    g.space = box.schema.space.create('with_sequence')
+    g.space:format({
+        {name = 'seq_id', type = 'unsigned', is_nullable = false},
+        {name = 'first', type = 'string', is_nullable = false},
+        {name = 'second', type = 'string', is_nullable = false},
+    })
+
+    local seq_name = 'seq'
+    local seq_opts = {
+        start = 10,
+        min = 10,
+        max = 1000,
+        cycle = false,
+        cache = 0,
+        step = 5,
+    }
+    box.schema.sequence.create(seq_name, seq_opts)
+
+    g.space:create_index('seq_index', {
+        type = 'TREE',
+        unique = true,
+        parts = {{is_nullable = false, field = 'seq_id', type = 'unsigned'}},
+        sequence = seq_name,
+    })
+
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_str_contains(err, 'Incompatible schema: sequences["seq"] max ' ..
+                               '(expected 1000, got 1000000000000ULL)')
+end
+
+function g.test_sequence_schema_with_defaults_apply_fails_if_existing_sequence_has_different_options()
+    g.space = box.schema.space.create('with_sequence')
+    g.space:format({
+        {name = 'seq_id', type = 'unsigned', is_nullable = false},
+        {name = 'first', type = 'string', is_nullable = false},
+        {name = 'second', type = 'string', is_nullable = false},
+    })
+
+    local seq_name = 'seq'
+    local seq_opts = {
+        start = 10,
+        min = 10,
+        max = 1000,
+        cycle = false,
+        cache = 0,
+        step = 5,
+    }
+    box.schema.sequence.create(seq_name, seq_opts)
+
+    g.space:create_index('seq_index', {
+        type = 'TREE',
+        unique = true,
+        parts = {{is_nullable = false, field = 'seq_id', type = 'unsigned'}},
+        sequence = seq_name,
+    })
+
+    local test_schema = table.deepcopy(test_schema)
+    test_schema.sequences['seq'] = {} -- Fill with defaults.
+
+    local _, err = ddl.set_schema(test_schema)
+    t.assert_str_contains(err, 'Incompatible schema: sequences["seq"] max '..
+                               '(expected 1000, got nil and default is 9223372036854775807ULL)')
+end

--- a/test/utils_test.lua
+++ b/test/utils_test.lua
@@ -23,3 +23,26 @@ function g.test_find_first_duplicate()
     t.assert_equals(ddl_utils.find_first_duplicate(objects, 'key'), 4)
     t.assert_not(ddl_utils.find_first_duplicate(objects, 'value'))
 end
+
+function g.test_is_number()
+    t.assert(ddl_utils.is_number(0))
+    t.assert(ddl_utils.is_number(1))
+    t.assert(ddl_utils.is_number(1.213))
+    t.assert(ddl_utils.is_number(-1.213))
+    t.assert(ddl_utils.is_number(math.huge))
+    t.assert(ddl_utils.is_number(0 / 0))
+    t.assert(ddl_utils.is_number(1LL))
+    t.assert(ddl_utils.is_number(1ULL))
+
+    t.assert_not(ddl_utils.is_number(nil))
+    t.assert_not(ddl_utils.is_number(box.NULL))
+    t.assert_not(ddl_utils.is_number(''))
+    t.assert_not(ddl_utils.is_number('1.234'))
+    t.assert_not(ddl_utils.is_number({1, 2,}))
+end
+
+function g.test_concat_arrays()
+    t.assert(ddl_utils.concat_arrays({1}, {2, 3}), {1, 2, 3})
+    t.assert(ddl_utils.concat_arrays({}, {2, 3}), {2, 3})
+    t.assert(ddl_utils.concat_arrays({1}, {}), {1})
+end


### PR DESCRIPTION
This patch adds the support of sequences through new schema section, as well as proper support of sequence option for indexes. Before this patch, ddl had half-baked support of sequences: one could provide `sequence` as sequence name in indexes and it would be created. This approach was broken in basic `set_schema(get_schema)` scenario since there wasn't any sequences support in get. Current design is inspired by existing "not implemented yet" tests and documentation examples.

Closes #122