### PR TITLE
ci: bump ubuntu version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -18,7 +18,7 @@ jobs:
 
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
@@ -29,15 +29,15 @@ jobs:
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
     needs: version-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '2.11'
 
       - name: Prepare apt repo
-        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+        run: curl -L https://tarantool.io/release/3/installer.sh | bash
 
       - name: Install tt cli
         run: sudo apt install -y tt

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Clone the ddl module
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup tt
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          curl -L https://tarantool.io/release/3/installer.sh | sudo bash
           sudo apt install -y tt
           tt version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,27 +9,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['1.10', '2.5', '2.6', '2.7', '2.8', '2.10']
-        coveralls: [false]
-        include:
-          - tarantool: '2.11'
-            coveralls: true
-    # There are problems with current version of the
-    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
-    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
-    # will be resolved. See [1] for details.
-    #
-    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
-    runs-on: [ubuntu-20.04]
+        tarantool: ['2.11', '3.3']
+
+    runs-on: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
       - name: Prepare apt repo
-        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+        run: curl -L https://tarantool.io/release/3/installer.sh | bash
 
       - name: Install tt cli
         run: sudo apt install -y tt
@@ -38,7 +29,7 @@ jobs:
 
       # Setup luatest and luacheck
       - name: Cache rocks
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-rocks
         with:
           path: .rocks/
@@ -66,10 +57,11 @@ jobs:
 
       - name: Run tests and code coverage analysis
         run: make -C build coverage
+        if: ${{ startsWith(matrix.tarantool, '2.') }}
 
       - name: Send code coverage to coveralls.io
         run: make -C build coveralls
-        if: ${{ matrix.coveralls }}
+        if: ${{ startsWith(matrix.tarantool, '2.') }}
 
       # Cleanup cached paths
       - run: tt rocks remove cartridge
@@ -78,23 +70,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tarantool: ['2.11']
-    # There are problems with current version of the
-    # setup-tarantool action on Ubuntu Jammy (ubuntu-latest or
-    # ubuntu-22.04). Use Ubuntu Focal (ubuntu-20.04) until they
-    # will be resolved. See [1] for details.
-    #
-    # [1]: https://github.com/tarantool/setup-tarantool/issues/36
-    runs-on: [ubuntu-20.04]
+        tarantool: ['2.11', '3.3']
+
+    runs-on: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 
       - name: Prepare apt repo
-        run: curl -L https://tarantool.io/release/2/installer.sh | bash
+        run: curl -L https://tarantool.io/release/3/installer.sh | bash
 
       - name: Install tt cli
         run: sudo apt install -y tt
@@ -103,7 +90,7 @@ jobs:
 
       # Setup luatest
       - name: Cache rocks
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-rocks
         with:
           path: .rocks/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...3.31 FATAL_ERROR)
 
 project(ddl C)
 

--- a/README.md
+++ b/README.md
@@ -349,5 +349,6 @@ tt rocks make
 ```bash
 tt rocks install luatest 0.5.7
 tt rocks install luacheck 0.25.0
+tt rocks install cartridge
 make test -C build.luarocks ARGS="-V"
 ```

--- a/test/role_test.lua
+++ b/test/role_test.lua
@@ -4,8 +4,11 @@ local g = t.group()
 local fio = require('fio')
 local yaml = require('yaml')
 local helpers = require('test.helper')
+local tarantool_helpers = require('test.tarantool_helpers')
 
 g.before_all(function()
+    tarantool_helpers.skip_if_tarantool3()
+
     t.skip_if(
         not pcall(require, 'cartridge'),
         'cartridge not installed'

--- a/test/tarantool_helpers.lua
+++ b/test/tarantool_helpers.lua
@@ -1,0 +1,15 @@
+local luatest = require('luatest')
+local luatest_utils = require('luatest.utils')
+
+local tarantool_helpers = {}
+
+tarantool_helpers.is_tarantool3 = function()
+    local tarantool_version = luatest_utils.get_tarantool_version()
+    return luatest_utils.version_ge(tarantool_version, luatest_utils.version(3, 0, 0))
+end
+
+tarantool_helpers.skip_if_tarantool3 = function()
+    luatest.skip_if(tarantool_helpers.is_tarantool3(), 'Tarantool 3 is not supported')
+end
+
+return tarantool_helpers


### PR DESCRIPTION
Bump actions to use ubuntu-24.04 for fixing the following GitHub warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Update list of `tarantool` versions to test.

Part of #TNTP-1918